### PR TITLE
Add preprocessing, training, inference, and cross-validation scripts

### DIFF
--- a/cnn_cv.py
+++ b/cnn_cv.py
@@ -1,0 +1,176 @@
+import argparse
+import json
+import os
+from typing import Dict, List
+
+import matplotlib.pyplot as plt
+import numpy as np
+import torch
+import torch.nn as nn
+import torch.optim as optim
+from sklearn.metrics import mean_absolute_error, mean_squared_error, r2_score
+from sklearn.model_selection import KFold
+from torch.utils.data import DataLoader, Dataset
+
+from util import Simple1DCNN
+
+
+class ListDataset(Dataset):
+    """Dataset wrapping a list of samples."""
+
+    def __init__(self, data: List[Dict[str, object]], target_key: str):
+        self.data = data
+        self.target_key = target_key
+
+    def __len__(self) -> int:
+        return len(self.data)
+
+    def __getitem__(self, idx: int):
+        item = self.data[idx]
+        matrix = torch.tensor(item["input_matrix"], dtype=torch.float32)
+        target = torch.tensor([item[self.target_key]], dtype=torch.float32)
+        return matrix, target
+
+
+def train_and_eval(
+    train_loader: DataLoader,
+    val_loader: DataLoader,
+    epochs: int,
+    lr: float,
+    device: torch.device,
+) -> Dict[str, float]:
+    """Train model and evaluate on validation set."""
+    model = Simple1DCNN(input_size=20).to(device)
+    criterion = nn.MSELoss()
+    optimizer = optim.Adam(model.parameters(), lr=lr)
+
+    for _ in range(epochs):
+        model.train()
+        for data, target in train_loader:
+            data, target = data.to(device), target.to(device)
+            optimizer.zero_grad()
+            output = model(data)
+            loss = criterion(output, target)
+            loss.backward()
+            optimizer.step()
+
+    model.eval()
+    preds = []
+    gts = []
+    with torch.no_grad():
+        for data, target in val_loader:
+            data, target = data.to(device), target.to(device)
+            output = model(data)
+            preds.extend(output.cpu().numpy().flatten().tolist())
+            gts.extend(target.cpu().numpy().flatten().tolist())
+
+    rmse = float(np.sqrt(mean_squared_error(gts, preds)))
+    mae = float(mean_absolute_error(gts, preds))
+    r2 = float(r2_score(gts, preds))
+    return {"rmse": rmse, "mae": mae, "r2": r2, "preds": preds, "gts": gts}
+
+
+def plot_results(
+    y_true: List[float], y_pred: List[float], fold_dir: str
+) -> None:
+    """Save parity and residual plots."""
+    os.makedirs(fold_dir, exist_ok=True)
+
+    plt.figure(figsize=(6, 6))
+    plt.scatter(y_true, y_pred, alpha=0.6)
+    plt.plot([min(y_true), max(y_true)], [min(y_true), max(y_true)], "r--")
+    plt.xlabel("True")
+    plt.ylabel("Predicted")
+    plt.tight_layout()
+    plt.savefig(os.path.join(fold_dir, "parity.png"))
+    plt.close()
+
+    residuals = np.array(y_pred) - np.array(y_true)
+    plt.figure(figsize=(6, 4))
+    plt.hist(residuals, bins=20, alpha=0.7)
+    plt.xlabel("Residual")
+    plt.ylabel("Count")
+    plt.tight_layout()
+    plt.savefig(os.path.join(fold_dir, "residuals.png"))
+    plt.close()
+
+
+def main() -> None:
+    """Perform K-fold cross-validation."""
+    parser = argparse.ArgumentParser(description="CNN cross-validation")
+    parser.add_argument(
+        "--data", required=True, help="Processed data directory"
+    )
+    parser.add_argument("--target", required=True, help="Target name")
+    parser.add_argument("--folds", type=int, default=5, help="Number of folds")
+    parser.add_argument(
+        "--epochs", type=int, default=50, help="Training epochs"
+    )
+    parser.add_argument(
+        "--batch_size", type=int, default=32, help="Batch size"
+    )
+    parser.add_argument("--lr", type=float, default=1e-3, help="Learning rate")
+    parser.add_argument("--outdir", default=".", help="Output directory")
+    parser.add_argument("--seed", type=int, default=42, help="Random seed")
+    args = parser.parse_args()
+
+    data = []
+    for split in ("train", "val", "test"):
+        path = os.path.join(args.data, f"{split}.json")
+        if os.path.exists(path):
+            with open(path, "r", encoding="utf-8") as f:
+                data.extend(json.load(f))
+    if not data:
+        raise ValueError("No data found in provided directory")
+
+    kf = KFold(n_splits=args.folds, shuffle=True, random_state=args.seed)
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+    base_dir = os.path.join(args.outdir, "runs", f"cv_{args.target}")
+    os.makedirs(base_dir, exist_ok=True)
+
+    metrics_list = []
+    for fold, (train_idx, val_idx) in enumerate(kf.split(data), start=1):
+        train_samples = [data[i] for i in train_idx]
+        val_samples = [data[i] for i in val_idx]
+
+        train_loader = DataLoader(
+            ListDataset(train_samples, args.target),
+            batch_size=args.batch_size,
+            shuffle=True,
+        )
+        val_loader = DataLoader(
+            ListDataset(val_samples, args.target),
+            batch_size=args.batch_size,
+            shuffle=False,
+        )
+
+        result = train_and_eval(
+            train_loader, val_loader, args.epochs, args.lr, device
+        )
+        fold_dir = os.path.join(base_dir, f"fold_{fold}")
+        plot_results(result["gts"], result["preds"], fold_dir)
+        metrics = {
+            k: v for k, v in result.items() if k not in {"gts", "preds"}
+        }
+        metrics_list.append(metrics)
+        with open(
+            os.path.join(fold_dir, "metrics.json"), "w", encoding="utf-8"
+        ) as f:
+            json.dump(metrics, f, indent=2)
+
+    aggregate = {}
+    for key in metrics_list[0].keys():
+        values = [m[key] for m in metrics_list]
+        aggregate[key] = {
+            "mean": float(np.mean(values)),
+            "std": float(np.std(values, ddof=0)),
+        }
+    with open(
+        os.path.join(base_dir, "aggregate_metrics.json"), "w", encoding="utf-8"
+    ) as f:
+        json.dump(aggregate, f, indent=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/predict.py
+++ b/predict.py
@@ -1,0 +1,102 @@
+import argparse
+import json
+import os
+from typing import Dict, List
+
+import pandas as pd
+import torch
+from torch.utils.data import DataLoader, Dataset
+
+from util import Simple1DCNN
+
+
+class InferenceDataset(Dataset):
+    """Dataset for inference inputs."""
+
+    def __init__(self, samples: List[Dict[str, object]]):
+        self.samples = samples
+
+    def __len__(self) -> int:
+        return len(self.samples)
+
+    def __getitem__(self, idx: int):
+        sample = self.samples[idx]
+        matrix = torch.tensor(sample["input_matrix"], dtype=torch.float32)
+        return sample["id"], matrix
+
+
+def load_models(
+    model_paths: List[str], input_size: int, device: torch.device
+) -> Dict[str, Simple1DCNN]:
+    """Load models from disk.
+
+    Args:
+        model_paths: List of model file paths.
+        input_size: Width of the input matrix.
+        device: Torch device.
+
+    Returns:
+        Mapping from target name to loaded model.
+    """
+    models = {}
+    for path in model_paths:
+        target = os.path.splitext(os.path.basename(path))[0]
+        model = Simple1DCNN(input_size=input_size)
+        model.load_state_dict(torch.load(path, map_location=device))
+        model.to(device)
+        model.eval()
+        models[target] = model
+    return models
+
+
+def main() -> None:
+    """Run batch inference on new inputs."""
+    parser = argparse.ArgumentParser(description="Batch inference")
+    parser.add_argument(
+        "--model", nargs="+", required=True, help="Model file paths"
+    )
+    parser.add_argument("--inputs", required=True, help="Path to inputs JSON")
+    parser.add_argument("--out_csv", required=True, help="Output CSV path")
+    parser.add_argument(
+        "--device",
+        choices=["cpu", "cuda"],
+        default="cpu",
+        help="Computation device",
+    )
+    parser.add_argument(
+        "--batch_size", type=int, default=32, help="Batch size"
+    )
+    args = parser.parse_args()
+
+    with open(args.inputs, "r", encoding="utf-8") as f:
+        samples = json.load(f)
+
+    dataset = InferenceDataset(samples)
+    loader = DataLoader(dataset, batch_size=args.batch_size, shuffle=False)
+
+    input_size = len(samples[0]["input_matrix"][0])
+    device = torch.device(
+        args.device
+        if torch.cuda.is_available() or args.device == "cpu"
+        else "cpu"
+    )
+    models = load_models(args.model, input_size, device)
+
+    results = {"id": []}
+    for target in models:
+        results[target + "_pred"] = []
+
+    with torch.no_grad():
+        for ids, matrices in loader:
+            matrices = matrices.to(device)
+            results["id"].extend(ids)
+            for target, model in models.items():
+                preds = model(matrices).cpu().numpy().flatten().tolist()
+                results[target + "_pred"].extend(preds)
+
+    df = pd.DataFrame(results)
+    df.to_csv(args.out_csv, index=False)
+
+
+if __name__ == "__main__":
+    main()

--- a/preprocess_csv.py
+++ b/preprocess_csv.py
@@ -1,0 +1,118 @@
+import argparse
+import json
+import os
+import random
+from typing import Dict, List
+
+import numpy as np
+import pandas as pd
+
+from data_processor import convert_to_matrix, parse_input_list
+
+
+def build_sample(row: pd.Series) -> Dict[str, object]:
+    """Build a single dataset sample from a CSV row.
+
+    Args:
+        row: A row from the raw CSV.
+
+    Returns:
+        A dictionary with the model input matrix and target values.
+    """
+    input_list = parse_input_list(row["Input List"])
+    matrix = convert_to_matrix(input_list)
+
+    sample = {
+        "id": row["Name"],
+        "input_matrix": matrix.tolist(),
+    }
+
+    for col in row.index:
+        if col in {"Input List", "Name"}:
+            continue
+        sample[col] = float(row[col])
+    return sample
+
+
+def compute_stats(
+    data: List[Dict[str, object]], target_names: List[str]
+) -> Dict[str, Dict[str, float]]:
+    """Compute mean and standard deviation for each target."""
+    stats: Dict[str, Dict[str, float]] = {}
+    for name in target_names:
+        values = np.array([d[name] for d in data], dtype=float)
+        stats[name] = {
+            "mean": float(values.mean()),
+            "std": float(values.std(ddof=0)),
+        }
+    return stats
+
+
+def main() -> None:
+    """Entry point for CSV preprocessing."""
+    parser = argparse.ArgumentParser(
+        description="Preprocess CSV into model-ready datasets"
+    )
+    parser.add_argument("--csv", required=True, help="Path to raw CSV file")
+    parser.add_argument(
+        "--outdir", default="Data/processed", help="Output directory"
+    )
+    parser.add_argument(
+        "--split_seed", type=int, default=42, help="Random seed for splits"
+    )
+    parser.add_argument(
+        "--val_frac", type=float, default=0.1, help="Validation fraction"
+    )
+    parser.add_argument(
+        "--test_frac", type=float, default=0.1, help="Test fraction"
+    )
+    args = parser.parse_args()
+
+    if args.val_frac + args.test_frac >= 1:
+        raise ValueError("val_frac and test_frac must sum to less than 1")
+
+    os.makedirs(args.outdir, exist_ok=True)
+
+    df = pd.read_csv(args.csv)
+    samples = [build_sample(row) for _, row in df.iterrows()]
+
+    random.Random(args.split_seed).shuffle(samples)
+
+    n_total = len(samples)
+    n_val = int(n_total * args.val_frac)
+    n_test = int(n_total * args.test_frac)
+    n_train = n_total - n_val - n_test
+
+    train = samples[:n_train]
+    val = samples[n_train:n_train + n_val]
+    test = samples[n_train + n_val:]
+
+    targets = [c for c in df.columns if c not in {"Input List", "Name"}]
+
+    splits = {"train": train, "val": val, "test": test}
+    for name, data in splits.items():
+        with open(
+            os.path.join(args.outdir, f"{name}.json"), "w", encoding="utf-8"
+        ) as f:
+            json.dump(data, f, indent=2)
+
+    meta = {
+        "targets": targets,
+        "feature_shape": [3, 20],
+        "num_samples": {
+            "train": n_train,
+            "val": n_val,
+            "test": n_test,
+        },
+        "seed": args.split_seed,
+        "normalization": compute_stats(train, targets),
+    }
+
+    with open(
+        os.path.join(args.outdir, "meta.json"), "w", encoding="utf-8"
+    ) as f:
+        json.dump(meta, f, indent=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/train_targets.py
+++ b/train_targets.py
@@ -1,0 +1,199 @@
+import argparse
+import json
+import os
+import random
+from typing import List, Tuple
+
+import numpy as np
+import torch
+import torch.nn as nn
+import torch.optim as optim
+from sklearn.metrics import mean_absolute_error, mean_squared_error, r2_score
+from torch.utils.data import DataLoader
+
+from util import MatrixDataset, Simple1DCNN
+
+
+def set_seed(seed: int) -> None:
+    """Set random seeds for reproducibility."""
+    random.seed(seed)
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+    torch.cuda.manual_seed_all(seed)
+
+
+def train_one(
+    target: str,
+    train_loader: DataLoader,
+    val_loader: DataLoader,
+    epochs: int,
+    lr: float,
+    weight_decay: float,
+    patience: int,
+    device: torch.device,
+) -> Tuple[Simple1DCNN, dict, List[str]]:
+    """Train a single target model with early stopping.
+
+    Args:
+        target: Target name.
+        train_loader: DataLoader for training data.
+        val_loader: DataLoader for validation data.
+        epochs: Maximum number of epochs.
+        lr: Learning rate.
+        weight_decay: Weight decay.
+        patience: Early stopping patience.
+        device: Torch device.
+
+    Returns:
+        Tuple of (best model, metrics dict, training log lines).
+    """
+    model = Simple1DCNN(input_size=20).to(device)
+    criterion = nn.MSELoss()
+    optimizer = optim.Adam(
+        model.parameters(), lr=lr, weight_decay=weight_decay
+    )
+
+    best_val_loss = float("inf")
+    best_epoch = -1
+    epochs_without_improve = 0
+    train_log: List[str] = []
+    best_metrics = {}
+
+    for epoch in range(1, epochs + 1):
+        model.train()
+        total_train_loss = 0.0
+        for data, target_vals in train_loader:
+            data = data.to(device)
+            target_vals = target_vals.to(device)
+            optimizer.zero_grad()
+            outputs = model(data)
+            loss = criterion(outputs, target_vals)
+            loss.backward()
+            optimizer.step()
+            total_train_loss += loss.item() * data.size(0)
+        avg_train_loss = total_train_loss / len(train_loader.dataset)
+
+        model.eval()
+        total_val_loss = 0.0
+        preds = []
+        gts = []
+        with torch.no_grad():
+            for data, target_vals in val_loader:
+                data = data.to(device)
+                target_vals = target_vals.to(device)
+                outputs = model(data)
+                loss = criterion(outputs, target_vals)
+                total_val_loss += loss.item() * data.size(0)
+                preds.extend(outputs.cpu().numpy().flatten().tolist())
+                gts.extend(target_vals.cpu().numpy().flatten().tolist())
+        avg_val_loss = total_val_loss / len(val_loader.dataset)
+
+        log_line = (
+            f"Epoch {epoch}: train_loss={avg_train_loss:.6f}, "
+            f"val_loss={avg_val_loss:.6f}"
+        )
+        train_log.append(log_line)
+
+        if avg_val_loss < best_val_loss:
+            best_val_loss = avg_val_loss
+            best_epoch = epoch
+            epochs_without_improve = 0
+            rmse = float(np.sqrt(mean_squared_error(gts, preds)))
+            mae = float(mean_absolute_error(gts, preds))
+            r2 = float(r2_score(gts, preds))
+            best_metrics = {
+                "val_loss": best_val_loss,
+                "rmse": rmse,
+                "mae": mae,
+                "r2": r2,
+                "train_loss": avg_train_loss,
+            }
+            best_state = model.state_dict()
+        else:
+            epochs_without_improve += 1
+            if epochs_without_improve >= patience:
+                break
+
+    model.load_state_dict(best_state)
+    return model, {"best_epoch": best_epoch, **best_metrics}, train_log
+
+
+def main() -> None:
+    """Train and save one model per target."""
+    parser = argparse.ArgumentParser(
+        description="Train CNN models for multiple targets"
+    )
+    parser.add_argument(
+        "--data", required=True, help="Directory with processed train/val data"
+    )
+    parser.add_argument(
+        "--targets",
+        nargs="*",
+        default=["area_avg", "rg_avg", "rdf_peak"],
+        help="Target names to train",
+    )
+    parser.add_argument(
+        "--epochs", type=int, default=100, help="Maximum epochs"
+    )
+    parser.add_argument(
+        "--batch_size", type=int, default=32, help="Batch size"
+    )
+    parser.add_argument("--lr", type=float, default=1e-3, help="Learning rate")
+    parser.add_argument(
+        "--weight_decay", type=float, default=0.0, help="Weight decay"
+    )
+    parser.add_argument(
+        "--patience", type=int, default=10, help="Early stopping patience"
+    )
+    parser.add_argument("--outdir", default=".", help="Output directory")
+    parser.add_argument("--seed", type=int, default=42, help="Random seed")
+    args = parser.parse_args()
+
+    set_seed(args.seed)
+
+    train_path = os.path.join(args.data, "train.json")
+    val_path = os.path.join(args.data, "val.json")
+
+    os.makedirs(os.path.join(args.outdir, "models"), exist_ok=True)
+    os.makedirs(os.path.join(args.outdir, "runs"), exist_ok=True)
+
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+    for target in args.targets:
+        train_dataset = MatrixDataset(train_path, target_key=target)
+        val_dataset = MatrixDataset(val_path, target_key=target)
+        train_loader = DataLoader(
+            train_dataset, batch_size=args.batch_size, shuffle=True
+        )
+        val_loader = DataLoader(
+            val_dataset, batch_size=args.batch_size, shuffle=False
+        )
+
+        model, metrics, log_lines = train_one(
+            target,
+            train_loader,
+            val_loader,
+            args.epochs,
+            args.lr,
+            args.weight_decay,
+            args.patience,
+            device,
+        )
+
+        model_path = os.path.join(args.outdir, "models", f"{target}.pth")
+        torch.save(model.state_dict(), model_path)
+
+        run_dir = os.path.join(args.outdir, "runs", target)
+        os.makedirs(run_dir, exist_ok=True)
+        with open(
+            os.path.join(run_dir, "metrics.json"), "w", encoding="utf-8"
+        ) as f:
+            json.dump(metrics, f, indent=2)
+        with open(
+            os.path.join(run_dir, "train_log.txt"), "w", encoding="utf-8"
+        ) as f:
+            f.write("\n".join(log_lines))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Add `preprocess_csv.py` to convert raw CSVs into train/val/test splits with normalization stats
- Add `train_targets.py` to train one CNN per target with early stopping and metric logging
- Add `predict.py` for batched inference over saved models
- Add `cnn_cv.py` to run K-fold cross-validation and save plots and metrics

## Testing
- `flake8 preprocess_csv.py train_targets.py predict.py cnn_cv.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a610e888d883238273e31dec0dbe49